### PR TITLE
Use Kirby's Url::path() to sanitize dir

### DIFF
--- a/lib/Vite.php
+++ b/lib/Vite.php
@@ -2,6 +2,7 @@
 
 namespace arnoson\KirbyVite;
 
+use Kirby\Http\Url;
 use Kirby\Toolkit\F;
 use Kirby\Toolkit\Str;
 use \Exception;
@@ -26,15 +27,7 @@ class Vite {
    * sanitizeDir('test') // => '/test'
    */
   protected function sanitizeDir(string $dir): string {
-    if (!Str::startsWith($dir, '/')) {
-      $dir = "/{$dir}";
-    }
-
-    if (Str::endsWith($dir, '/')) {
-      $dir = substr($dir, 0, -1);
-    }
-
-    return $dir;
+    return Url::path($dir, true, false);
   }
 
   /**


### PR DESCRIPTION
Hi there,

Kirby ships with a function to [trim or add leading and trailing slashes](https://getkirby.com/docs/reference/tools/url/path). Less verbose than your current implementation but would decrease the plugin's code overhead. Maybe you like the change. 🙂 

Edit: Thanks for your work on this plugin as well as featuring my starter kit in your readme. Much appreciated.