### PR TITLE
fix: deprecated dynamic property

### DIFF
--- a/lib/Vite.php
+++ b/lib/Vite.php
@@ -7,6 +7,7 @@ use \Exception;
 class Vite {
   protected static Vite $instance;
   protected $isFirstScript = true;
+  protected ?array $manifest = null;
 
   public static function getInstance() {
     return self::$instance ??= new self();


### PR DESCRIPTION
When running `npm run preview` on PHP 8.2 an deprecated warning will appear:

`Creation of dynamic property arnoson\KirbyVite\Vite::$manifest is deprecated`

This means that using the var keyword to create dynamic properties is no longer allowed in PHP 8.2, and you should instead declare properties explicitly in the class definition.

To quickly fix this issue, I've declared the $manifest property in the Vite class definition as follows:
`protected ?array $manifest = null;`