### PR TITLE
Handles paths differences

### DIFF
--- a/packages/kirby-vite/Vite.php
+++ b/packages/kirby-vite/Vite.php
@@ -5,11 +5,11 @@ use Kirby\Filesystem\F;
 use \Exception;
 
 function getRelativePath($rootPath, $fullPath) {
-  $rootPath = rtrim($rootPath, '/');
-  $fullPath = rtrim($fullPath, '/');
+  $rootPath = realpath(rtrim($rootPath, '/'));
+  $fullPath = realpath(rtrim($fullPath, '/'));
 
   if (strpos($fullPath, $rootPath) === 0) {
-    $relativePath = ltrim(substr($fullPath, strlen($rootPath)), '/');
+    $relativePath = ltrim(substr($fullPath, strlen($rootPath)), DIRECTORY_SEPARATOR);
     return $relativePath;
   }
 


### PR DESCRIPTION
This PR solves the issue mentioned in #27 where the paths inside `getRelativePath` are handled differently on Windows and Linux.

- added `realpath()` to ensure consistent path handling across different operating systems
- added `DIRECTORY_SEPARATOR` to represent the correct directory separator for the current operating system