### PR TITLE
vite-kirby-plugin enhancements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "arnoson/kirby-vite",
   "description": "Vite helper for Kirby CMS",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "type": "kirby-plugin",
   "license": "MIT",
   "authors": [
@@ -14,5 +14,10 @@
   },
   "require": {
     "getkirby/composer-installer": "^1.2"
+  },
+  "config": {
+    "allow-plugins": {
+      "getkirby/composer-installer": true
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,11 @@
 {
   "name": "kirby-vite",
+  "version": "4.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "version": "4.0.7",
       "devDependencies": {
         "@prettier/plugin-php": "^0.19.6",
         "bumpp": "^9.1.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0.6",
+  "version": "4.0.7",
   "scripts": {
     "test": "composer run test",
     "release": "bumpp -r",

--- a/packages/vite-plugin-kirby/package-lock.json
+++ b/packages/vite-plugin-kirby/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-kirby",
-  "version": "0.2.1",
+  "version": "4.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-kirby",
-      "version": "0.2.1",
+      "version": "4.0.7",
       "license": "MIT",
       "dependencies": {
         "vite-plugin-live-reload": "^3.0.2"

--- a/packages/vite-plugin-kirby/package.json
+++ b/packages/vite-plugin-kirby/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-kirby",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/vite-plugin-kirby/src/index.ts
+++ b/packages/vite-plugin-kirby/src/index.ts
@@ -1,5 +1,5 @@
 import type { Plugin, ViteDevServer } from 'vite'
-import { relative, resolve } from 'node:path'
+import { relative, resolve, sep } from 'node:path'
 import { writeFile, unlink } from 'node:fs/promises'
 import { liveReload } from 'vite-plugin-live-reload'
 
@@ -55,7 +55,7 @@ export default (
       // Share some essential Vite config with Kirby.
       let { outDir, assetsDir } = build
       // PHP needs the `outDir` relative to the project's root (cwd).
-      outDir = relative(process.cwd(), resolve(root, outDir))
+      outDir = relative(process.cwd(), resolve(root, outDir)).replace(/\//g, sep)
       const file = `${kirbyConfigDir}/vite.config.php`
       const legacy = !!plugins.find((v) => v.name === 'vite:legacy-config')
       writeFile(file, phpConfigTemplate({ outDir, assetsDir, legacy }))


### PR DESCRIPTION
Hi @arnoson, I'm back with some improvement ideas :)

**Issues**
1. The current vite.config file generates with an '\' path separator which I found that on some of my projects, it has to be '/' in order to find the right directory path
2. Let's say you modify the vite.config file to your needs but every time you run vite the config file overrides itself

**Fixes**

1. By using `sep` from the `path` module, the script will automatically use the appropriate separator for the operating system. This ensures that the `outDir` path will be formatted correctly for the current OS
2. I added a `try-catch` block around the access function to check the vite.config file already exists. If the file exists, it will skip the automatic override. This way, if you manually edit the file, the script won't override the changes.

Let me know your thoughts on these changes :)