### PR TITLE
fix: add `vite` as a peer-dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ composer require arnoson/kirby-vite
 ```
 
 ```
-npm install vite-plugin-kirby
+npm install vite vite-plugin-kirby
 ```
 
 ### Development VS Production modes

--- a/packages/vite-plugin-kirby/package-lock.json
+++ b/packages/vite-plugin-kirby/package-lock.json
@@ -19,6 +19,9 @@
         "tsup": "^6.7.0",
         "typescript": "^5.0.3",
         "vite": "^4.2.1"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.1"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/packages/vite-plugin-kirby/package.json
+++ b/packages/vite-plugin-kirby/package.json
@@ -40,5 +40,8 @@
   "homepage": "https://github.com/arnoson/vite-plugin-kirby#readme",
   "dependencies": {
     "vite-plugin-live-reload": "^3.0.2"
+  },
+  "peerDependencies": {
+    "vite": "^4.2.1"
   }
 }


### PR DESCRIPTION
…and mention it in the Installation part of the README.

